### PR TITLE
fix: Add semantic-release configuration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,16 @@
   "author": "",
   "license": "ISC",
   "description": "",
+  "release": {
+    "branches": ["main"],
+    "plugins": [
+      "@semantic-release/commit-analyzer",
+      "@semantic-release/release-notes-generator",
+      "@semantic-release/changelog",
+      "@semantic-release/git",
+      "@semantic-release/github"
+    ]
+  },
   "devDependencies": {
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/commit-analyzer": "^13.0.1",


### PR DESCRIPTION
🔧 Semantic-release fix:
- Add release configuration to package.json
- Override default npm plugin behavior
- Configure only GitHub releases (no npm publishing)
- Fix ENONPMTOKEN error in CI

📋 Configuration:
- Branches: main only
- Plugins: commit-analyzer, release-notes-generator
- Output: changelog, git tags, GitHub releases
- No npm registry publishing

✅ Benefits:
- Semantic-release works without npm token
- Automated versioning and releases on GitHub
- No more CI failures due to missing NPM_TOKEN
- Clean release management

🚀 Ready for automated releases